### PR TITLE
[RB] Fix duplicate test names

### DIFF
--- a/impl/rb/lib/uxid.rb
+++ b/impl/rb/lib/uxid.rb
@@ -1,9 +1,12 @@
+require "uxid/model"
 require "uxid/version"
 
-CROCKFORD_ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
-INVALID_REGEX = /[^#{CROCKFORD_ENCODING}]/
-
 module UXID
+  CROCKFORD_ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+  INVALID_REGEX = /[^#{CROCKFORD_ENCODING}]/
+  TIME_MAX = 2.pow(48) - 1
+  TIME_LEN = 10
+
   class Error < StandardError; end
   
   def self.decode value
@@ -14,8 +17,11 @@ module UXID
 
       elsif value =~ INVALID_REGEX
         raise "expected input to be a Base32 encoded string, got: '#{value}'"
+      else
+        UXID::Model.new value
       end
+    else
+      nil
     end
-    "uxid"
   end
 end

--- a/impl/rb/test/spec/0001_setup_api_test.rb
+++ b/impl/rb/test/spec/0001_setup_api_test.rb
@@ -20,11 +20,11 @@ class UXID0001Test < Minitest::Test
 
 
   # returns a UXID with input
-  def test_0001_setup_api_decoder
+  def test_returns_a_uxid_with_input
     input_string = "01E9VB3RWNAR89HSKMS84K9HCS"
 
     uxid = UXID.decode input_string
-    assert_kind_of ::UXID, uxid
+    assert_kind_of ::UXID::Model, uxid
     assert_equal "01E9VB3RWNAR89HSKMS84K9HCS", uxid.encoded
 
 
@@ -32,7 +32,7 @@ class UXID0001Test < Minitest::Test
 
 
   # rejects blank strings
-  def test_0001_setup_api_decoder
+  def test_rejects_blank_strings
     input_string = ""
 
     error = assert_raises { UXID.decode input_string }

--- a/impl/rb/test/spec/0101_basic_decoding_test.rb
+++ b/impl/rb/test/spec/0101_basic_decoding_test.rb
@@ -14,11 +14,11 @@ class UXID0101Test < Minitest::Test
 
 
   # accepts a ULID
-  def test_0101_basic_decoding_decoder
+  def test_accepts_a_ulid
     input_string = "01E9VB3RWNAR89HSKMS84K9HCS"
 
     uxid = UXID.decode input_string
-    assert_kind_of ::UXID, uxid
+    assert_kind_of ::UXID::Model, uxid
 
     assert_equal 1591129269141, uxid.time
 
@@ -26,11 +26,11 @@ class UXID0101Test < Minitest::Test
 
 
   # accepts the maximum allowed timestamp
-  def test_0101_basic_decoding_decoder
+  def test_accepts_the_maximum_allowed_timestamp
     input_string = "7ZZZZZZZZZZZZZZZZZZZZZZZZZ"
 
     uxid = UXID.decode input_string
-    assert_kind_of ::UXID, uxid
+    assert_kind_of ::UXID::Model, uxid
 
     assert_equal 281474976710655, uxid.time
 
@@ -38,7 +38,7 @@ class UXID0101Test < Minitest::Test
 
 
   # rejects malformed strings
-  def test_0101_basic_decoding_decoder
+  def test_rejects_malformed_strings
     input_string = "this is not a UXID"
 
     error = assert_raises { UXID.decode input_string }

--- a/spec_generator/templates/rb_spec.liquid
+++ b/spec_generator/templates/rb_spec.liquid
@@ -19,14 +19,14 @@ class UXID{{ group_id }}{{ spec_id }}Test < Minitest::Test
 {% if decoder_tests %}
 {% for test in decoder_tests %}
   # {{ test.name }}
-  def test_{{ group_id }}{{ spec_id }}_{{ group_name }}_{{ spec_name }}_decoder
+  def test_{{ test.name | downcase | replace: " ", "_" }}
     input_string = "{{ test.input }}"
 {% if test.error_message %}
     error = assert_raises { UXID.decode input_string }
     assert_equal "{{ test.error_message }}", error.message
 {% elsif test.verify %}
     uxid = UXID.decode input_string
-    assert_kind_of ::UXID, uxid
+    assert_kind_of ::UXID::Model, uxid
 {% if test.verify.encoded %}    assert_equal "{{ test.verify.encoded }}", uxid.encoded{% endif %}
 {% if test.verify.time %}    assert_equal {{ test.verify.time }}, uxid.time{% endif %}
 {% else %}


### PR DESCRIPTION
The generated Ruby specs had duplicate names of tests which causes some
to not run. This updates the Liquid template and the generated Ruby
specs to have unique names based on a cleanstring of the test name.

This adds time decoding to the Ruby implementation.

Relates #21 

Closes #21 