### PR TITLE
[PY] Fixes duplicate test names

### DIFF
--- a/impl/py/test/spec/0001_setup_api_test.py
+++ b/impl/py/test/spec/0001_setup_api_test.py
@@ -10,7 +10,7 @@ import uxid
 
 
 
-def test_0001_setup_api_api():
+def test_uxid_decode_exists():
     """
     UXID decode exists
     """
@@ -21,7 +21,7 @@ def test_0001_setup_api_api():
 
 
 
-def test_0001_setup_api_decoder():
+def test_returns_a_uxid_with_input():
     """
     returns a UXID with input
     """
@@ -33,7 +33,7 @@ def test_0001_setup_api_decoder():
 
 
 
-def test_0001_setup_api_decoder():
+def test_rejects_blank_strings():
     """
     rejects blank strings
     """

--- a/impl/py/test/spec/0101_basic_decoding_test.py
+++ b/impl/py/test/spec/0101_basic_decoding_test.py
@@ -13,7 +13,7 @@ import uxid
 
 
 
-def test_0101_basic_decoding_decoder():
+def test_accepts_a_ulid():
     """
     accepts a ULID
     """
@@ -25,7 +25,7 @@ def test_0101_basic_decoding_decoder():
     assert decoded_id.time == 1591129269141
 
 
-def test_0101_basic_decoding_decoder():
+def test_accepts_the_maximum_allowed_timestamp():
     """
     accepts the maximum allowed timestamp
     """
@@ -37,7 +37,7 @@ def test_0101_basic_decoding_decoder():
     assert decoded_id.time == 281474976710655
 
 
-def test_0101_basic_decoding_decoder():
+def test_rejects_malformed_strings():
     """
     rejects malformed strings
     """

--- a/impl/py/uxid/uxid.py
+++ b/impl/py/uxid/uxid.py
@@ -4,12 +4,28 @@
 
     Object representation of a UXID.
 """
+import math
 
 __all__ = ['UXID']
 
+CROCKFORD_ENCODING = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+TIME_LEN = 10
 
 class UXID(object):
-    __slots__ = ['encoded']
+    __slots__ = ['encoded', 'time']
 
     def __init__(self, encoded):
         self.encoded = encoded
+        self.decode_time()
+
+    def decode_time(self):
+        decoded_time = 0
+        time_chars = self.encoded[0:TIME_LEN][::-1]
+
+        for power_index in range(TIME_LEN):
+            char = time_chars[power_index]
+            power_value = math.pow(32, power_index)
+            alphabet_index = CROCKFORD_ENCODING.index(char)
+            decoded_time += power_value * alphabet_index
+
+        self.time = decoded_time

--- a/spec_generator/templates/py_spec.liquid
+++ b/spec_generator/templates/py_spec.liquid
@@ -10,7 +10,7 @@ import uxid
 {% if api_tests %}
 {% for test in api_tests %}
 {% capture args_string %}{% for arg in test.args %}"{{ arg }}"{% endfor %}{% endcapture %}
-def test_{{ group_id }}{{ spec_id }}_{{ group_name }}_{{ spec_name }}_api():
+def test_{{ test.name | downcase | replace: " ", "_" }}():
     """
     {{ test.name }}
     """
@@ -21,7 +21,7 @@ def test_{{ group_id }}{{ spec_id }}_{{ group_name }}_{{ spec_name }}_api():
 
 {% if decoder_tests %}
 {% for test in decoder_tests %}
-def test_{{ group_id }}{{ spec_id }}_{{ group_name }}_{{ spec_name }}_decoder():
+def test_{{ test.name | downcase | replace: " ", "_" }}():
     """
     {{ test.name }}
     """


### PR DESCRIPTION
The generated Python specs had duplicate names of tests which causes some
to not run. This updates the Liquid template and the generated Python
specs to have unique names based on a cleanstring of the test name.

This also adds time decoding to the Python implementation.

Relates #23 

Closes #23 