### PR TITLE
[EX] Fixes docs

### DIFF
--- a/impl/ex/lib/uxid.ex
+++ b/impl/ex/lib/uxid.ex
@@ -16,19 +16,6 @@ defmodule UXID do
 
   defstruct [:encoded, :prefix, :rand_size, :rand, :rand_encoded, :string, :time, :time_encoded]
 
-  @typedoc "A UXID struct."
-
-  @type t() :: %__MODULE__{
-          encoded: String.t() | nil,
-          prefix: String.t() | nil,
-          rand_size: pos_integer() | nil,
-          rand: binary() | nil,
-          rand_encoded: String.t() | nil,
-          string: String.t() | nil,
-          time: pos_integer() | nil,
-          time_encoded: Stream.t() | nil
-        }
-
   @typedoc "Options for generating a UXID"
   @type option :: {:time, integer()} | {:rand_size, integer()} | {:prefix, String.t()}
   @type options :: [option()]
@@ -38,6 +25,18 @@ defmodule UXID do
 
   @typedoc "An error string returned by the library if generation fails"
   @type error_string :: String.t()
+
+  @typedoc "A UXID struct"
+  @type t() :: %__MODULE__{
+          encoded: String.t() | nil,
+          prefix: String.t() | nil,
+          rand_size: pos_integer() | nil,
+          rand: binary() | nil,
+          rand_encoded: String.t() | nil,
+          string: String.t() | nil,
+          time: pos_integer() | nil,
+          time_encoded: String.t() | nil
+        }
 
   alias UXID.Decoder
   alias UXID.Encoder

--- a/impl/ex/mix.exs
+++ b/impl/ex/mix.exs
@@ -33,6 +33,9 @@ defmodule UXID.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       preferred_cli_env: preferred_cli_env(),
       test_coverage: [tool: ExCoveralls],
+
+      # Docs
+      source_url: "https://github.com/riddler/uxid",
       docs: docs()
     ]
   end
@@ -51,7 +54,7 @@ defmodule UXID.MixProject do
 
   defp docs do
     [
-      main: "README",
+      main: "readme",
       source_url: "https://github.com/riddler/uxid",
       source_ref: "ex-v#{@version}/impl/ex",
       extras: ["README.md"]


### PR DESCRIPTION
The UXID struct was referencing Stream.t() which was causing the
building of docs to fail.

This fixes the docs generation.