### PR TITLE
[EX] Adds optional dependencies

### DIFF
--- a/impl/ex/mix.exs
+++ b/impl/ex/mix.exs
@@ -9,11 +9,14 @@ defmodule UXID.MixProject do
   @deps [
     # Required
 
+    # Optional
+    {:ecto, "~> 3.5", optional: true},
+
     # Development, Documentation, Testing, ...
     {:ex_doc, "~> 0.22", only: :dev},
     {:benchee, "~> 1.0", only: :dev},
     {:benchee_html, "~> 1.0", only: :dev},
-    {:ecto_ulid, "~> 0.2", only: :dev}
+    {:ecto_ulid, "~> 0.2", only: :dev, optional: true}
   ]
 
   def application(), do: [extra_applications: [:crypto]]
@@ -33,6 +36,9 @@ defmodule UXID.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       preferred_cli_env: preferred_cli_env(),
       test_coverage: [tool: ExCoveralls],
+
+      # Exclude optional dependencies
+      xref: [exclude: Ecto.ParameterizedType],
 
       # Docs
       source_url: "https://github.com/riddler/uxid",


### PR DESCRIPTION
Compiling UXID in another project was raising the following:

warning: Ecto.ParameterizedType.__using__/1 defined in application :ecto is
used by the current application but the current application does not
directly depend on :ecto. To fix this, you must do one of:

  ...

  3. In case you don't want to add a requirement to :ecto, you may optionally
  skip this warning by adding [xref: [exclude: Ecto.ParameterizedType]] to your
  "def project" in mix.exs

This applies the suggestion by adding the xfref exclude.